### PR TITLE
[Bugfix] Returning generated code file name and vis file name through agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,6 @@ While the agent can plan spatial joins, it often fails to write functioning geop
 dataframes. Common issues include data type mismatches and coordinate system incompatibilities. We tried addressing 
 these with prompting, but without further tuning or a model specialized for geopandas, success rates across diverse 
 datasets will be limited.
+
+This agent relies on generative AI, which has inherent limitations. Retrying once or twice may yield better results 
+if an interaction is unsatisfactory.

--- a/geospatial_agent/agent/action_summarizer/action_summarizer.py
+++ b/geospatial_agent/agent/action_summarizer/action_summarizer.py
@@ -9,7 +9,7 @@ from geospatial_agent.agent.action_summarizer.prompts import _ACTION_SUMMARY_PRO
     _READ_FILE_PROMPT, _READ_FILE_REQUIREMENTS, _ACTION_SUMMARY_REQUIREMENTS, DATA_FRAMES_VARIABLE_NAME, \
     _DATA_SUMMARY_REQUIREMENTS, _DATA_SUMMARY_PROMPT
 from geospatial_agent.agent.shared import AgentSignal, EventType, SIGNAL_ACTION_CONTEXT_GENERATED, \
-    SENDER_ACTION_SUMMARIZER, SIGNAL_FILE_READ_CODE_GENERATED, SIGNAL_FILE_READ_CODE_EXECUTED
+    SENDER_ACTION_SUMMARIZER, SIGNAL_FILE_READ_CODE_GENERATED, SIGNAL_FILE_READ_CODE_EXECUTED, execute_assembled_code
 from geospatial_agent.shared.bedrock import get_claude_v2
 from geospatial_agent.shared.prompts import HUMAN_ROLE, ASSISTANT_ROLE, HUMAN_STOP_SEQUENCE
 from geospatial_agent.shared.shim import get_shim_imports
@@ -147,8 +147,7 @@ class ActionSummarizer:
     @staticmethod
     def _gen_file_summaries_from_executing_code(code: str) -> List[FileSummary]:
         assembled_code = f'{get_shim_imports()}\n{code}'
-        output = exec(assembled_code, globals(), globals())
-        _globals = globals()
+        output, _globals = execute_assembled_code(assembled_code)
 
         dataframes = _globals[DATA_FRAMES_VARIABLE_NAME]
         file_summaries = [FileSummary(**data) for data in dataframes]

--- a/geospatial_agent/agent/geo_chat/tools/gis_work_tool.py
+++ b/geospatial_agent/agent/geo_chat/tools/gis_work_tool.py
@@ -39,6 +39,9 @@ The return is freeform string or a URL to the result of the analysis."""
             user_input=user_input, session_id=session_id, storage_mode=storage_mode)
         output = gis_agent.invoke(action_summary=action_summary, session_id=session_id)
 
-        return "Observation: GIS Agent has completed it's work. This is the final answer."
+        return (f"Observation: GIS Agent has completed it's work. I should list the generated code file path, and "
+                f"generated visualization file path from the code output, if applicable."
+                f"Generated code path = {output.assembled_code_file_path}. "
+                f"Generated code output = {output.assembled_code_output}.")
 
     return Tool.from_function(func=gis_work_tool_func, name=GIS_WORK_TOOL, description=desc)

--- a/geospatial_agent/agent/shared.py
+++ b/geospatial_agent/agent/shared.py
@@ -1,4 +1,6 @@
+import sys
 from enum import Enum, auto
+from io import StringIO
 from typing import TypeVar
 from datetime import datetime
 
@@ -58,3 +60,18 @@ class AgentSignal(BaseModel):
     event_data: T = Field(default=None)
     event_type: EventType = Field(default=EventType.Message)
     is_final: bool = Field(default=False)
+
+
+def execute_assembled_code(assembled_code):
+    """Executes the assembled code and returns the output."""
+    old_stdout = sys.stdout
+    redirected_output = sys.stdout = StringIO()
+    try:
+        exec(assembled_code, globals(), globals())
+    except Exception as e:
+        raise e
+    finally:
+        sys.stdout = old_stdout
+
+    output = redirected_output.getvalue()
+    return output, globals()

--- a/geospatial_agent/shared/shim.py
+++ b/geospatial_agent/shared/shim.py
@@ -28,7 +28,9 @@ def get_data_file_url(file_path: str, session_id: str) -> str:
 
 def get_local_file_path(file_path: str, session_id: str, task_name: str = "") -> str:
     storage = LocalStorage()
-    return storage.get_generated_file_url(file_path=file_path, session_id=session_id, task_name=task_name)
+    file_url = storage.get_generated_file_url(file_path=file_path, session_id=session_id, task_name=task_name)
+    print(f"Resolved local file file_url = {file_url}")
+    return file_url
 
 
 class Storage(ABC):


### PR DESCRIPTION
Returning the generated code file and visualization file, may that be an html
or png was missed in the first release. I also simplified the `exec` usage
inside a single utility function.

As a bonus, I also noted that since this project uses Gen AI, it might require
one or more iterations to be successful.

test: Running the agent

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
